### PR TITLE
Sample the tournament corporation pool from a custom list

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -393,13 +393,9 @@ export class Game implements IGame, Logger {
     if (gameOptions.tournamentExpansion) {
       const tournamentCorps = CardManifest.keys(TOURNAMENT_CARD_MANIFEST.corporationCards);
       const custom = [...new Set(gameOptions.customCorporationsList)].filter((name) => tournamentCorps.includes(name));
-      if (custom.length > 0) {
-        tournamentPool = custom;
-      } else {
-        const names = [...tournamentCorps];
-        inplaceShuffle(names, rng);
-        tournamentPool = names.slice(0, constants.TOURNAMENT_CORPORATION_POOL_SIZE);
-      }
+      const candidates = custom.length > 0 ? custom : [...tournamentCorps];
+      inplaceShuffle(candidates, rng);
+      tournamentPool = candidates.slice(0, constants.TOURNAMENT_CORPORATION_POOL_SIZE);
       game.log('Tournament corporation pool: ${0}', (b) => b.rawString(tournamentPool?.join(', ') ?? ''));
     }
 

--- a/tests/TournamentMode.spec.ts
+++ b/tests/TournamentMode.spec.ts
@@ -55,6 +55,30 @@ describe('TournamentMode', () => {
     }
   });
 
+  it('customCorporationsList larger than the pool size is sampled down to 5', () => {
+    const custom = [
+      CardName.TERACTOR_TOURNAMENT,
+      CardName.ECOLINE_TOURNAMENT,
+      CardName.CREDICOR_TOURNAMENT,
+      CardName.INVENTRIX_TOURNAMENT,
+      CardName.PHOBOLOG_TOURNAMENT,
+      CardName.MANUTECH_TOURNAMENT,
+      CardName.RECYCLON_TOURNAMENT,
+      CardName.ECOTEC_TOURNAMENT,
+    ];
+    const [/* game */, p1, p2] = testGame(2, {
+      tournamentExpansion: true,
+      customCorporationsList: custom,
+    });
+
+    const names = (cards: ReadonlyArray<{name: CardName}>) => cards.map(toName).sort();
+    expect(p1.dealtCorporationCards).has.length(5);
+    expect(names(p2.dealtCorporationCards)).deep.eq(names(p1.dealtCorporationCards));
+    for (const name of p1.dealtCorporationCards.map(toName)) {
+      expect(custom).includes(name);
+    }
+  });
+
   it('Two players may play the same corporation', () => {
     const [game, p1, p2] = testGame(2, {tournamentExpansion: true});
     const first = new RecyclonTournament();


### PR DESCRIPTION
Unchecking corporations on the create game screen dealt every remaining tournament corporation to every player. The pool is now shuffled and capped at 5, so a custom list restricts the draw instead of replacing it.